### PR TITLE
Fix the warning even if the base url is set correctly

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,5 +1,5 @@
 export const onPreInit = ({ reporter }, pluginOptions) => {
-    if (!pluginOptions.serverURL) {
+    if (!pluginOptions.baseUrl) {
         reporter.warn(
             `The Chatwoot plugin requires a server url. Did you mean to add it?`,
         );


### PR DESCRIPTION
The plugin expects baseUrl instead of server URL