### PR TITLE
Change versions of peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "gatsby-*.js"
   ],
   "peerDependencies": {
-    "gatsby": "^2.19.5",
-    "react": "^16.12.0",
-    "react-dom": "^16.12.0"
+    "gatsby": ">= 2.19.5",
+    "react": ">= 16.12.0",
+    "react-dom": ">= 16.12.0"
   },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",


### PR DESCRIPTION
Fixes #7 

I have tested the plugin with latest version of gatsby and seems like gatsby isn't making breaking changes for plugin api. I think these changes will work for a long time and users won't be blocked for us to manually test and update the version. 

WDYT?